### PR TITLE
Add From<Error> for PyErr

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,12 @@ impl From<PyErr> for Error {
     }
 }
 
+impl Into<PyErr> for Error {
+    fn into(self) -> PyErr {
+        self.0
+    }
+}
+
 impl ser::Error for Error {
     fn custom<T: Display>(msg: T) -> Self {
         Error(PyRuntimeError::new_err(msg.to_string()))

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,9 +12,9 @@ impl From<PyErr> for Error {
     }
 }
 
-impl Into<PyErr> for Error {
-    fn into(self) -> PyErr {
-        self.0
+impl From<Error> for PyErr {
+    fn from(err: Error) -> Self {
+        err.0
     }
 }
 


### PR DESCRIPTION
This PR makes the PyErr implement `From<Error>`, simply unwrapping the inner PyO3 value. This allows the error type in this crate to be used with the `?` operator in functions returning `PyResult`, leading to better integration with PyO3 code