### PR TITLE
Update to pyo3 version 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ keywords      = ["serde", "pyo3", "python", "ffi"]
 license       = "MIT OR Apache-2.0"
 
 [dependencies]
-pyo3 = "0.20.0"
+pyo3 = "0.21.0"
 serde = "1.0.190"
 
 [dev-dependencies]
 maplit = "1.0.2"
-pyo3 = { version = "0.20.0", features = ["auto-initialize"] }
+pyo3 = { version = "0.21.0", features = ["auto-initialize"] }
 serde = { version = "1.0.190", features = ["derive"] }
 serde_json = "1.0.108"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ PyO3's PyAny as a serde data format
 
 ```rust
 use serde::Serialize;
-use pyo3::{Python, types::{PyAny, PyDict}};
+use pyo3::{Python, Bound, types::{PyAny, PyAnyMethods, PyDict}};
 use serde_pyobject::{to_pyobject, pydict};
 
 #[derive(Serialize)]
@@ -23,7 +23,7 @@ struct A {
 
 Python::with_gil(|py| {
     let a = A { a: 1, b: "test".to_string() };
-    let obj: &PyAny = to_pyobject(py, &a).unwrap();
+    let obj: Bound<PyAny> = to_pyobject(py, &a).unwrap();
     assert!(obj.eq(pydict! { py, "a" => 1, "b" => "test" }.unwrap()).unwrap());
 });
 ```
@@ -32,7 +32,7 @@ Python::with_gil(|py| {
 
 ```rust
 use serde::Deserialize;
-use pyo3::{Python, types::{PyAny, PyDict}};
+use pyo3::{Python, Bound, types::{PyAny, PyAnyMethods, PyDict}};
 use serde_pyobject::{from_pyobject, pydict};
 
 #[derive(Debug, PartialEq, Deserialize)]
@@ -42,7 +42,7 @@ struct A {
 }
 
 Python::with_gil(|py| {
-    let a: &PyDict = pydict! { py,
+    let a: Bound<PyDict> = pydict! { py,
       "a" => 1,
       "b" => "test"
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -307,13 +307,13 @@ impl<'de, 'py> de::Deserializer<'de> for PyAnyDeserializer<'py> {
         V: Visitor<'de>,
     {
         if self.0.is_instance_of::<PyDict>() {
-            return visitor.visit_map(MapDeserializer::new(self.0.downcast().unwrap()));
+            return visitor.visit_map(MapDeserializer::new(self.0.downcast()?));
         }
         if self.0.is_instance_of::<PyList>() {
-            return visitor.visit_seq(SeqDeserializer::from_list(self.0.downcast().unwrap()));
+            return visitor.visit_seq(SeqDeserializer::from_list(self.0.downcast()?));
         }
         if self.0.is_instance_of::<PyTuple>() {
-            return visitor.visit_seq(SeqDeserializer::from_tuple(self.0.downcast().unwrap()));
+            return visitor.visit_seq(SeqDeserializer::from_tuple(self.0.downcast()?));
         }
         if self.0.is_instance_of::<PyString>() {
             return visitor.visit_str(self.0.extract()?);
@@ -342,7 +342,7 @@ impl<'de, 'py> de::Deserializer<'de> for PyAnyDeserializer<'py> {
     ) -> Result<V::Value> {
         // Nested dict `{ "A": { "a": 1, "b": 2 } }` is deserialized as `A { a: 1, b: 2 }`
         if self.0.is_instance_of::<PyDict>() {
-            let dict: &Bound<PyDict> = self.0.downcast().unwrap();
+            let dict: &Bound<PyDict> = self.0.downcast()?;
             if let Some(inner) = dict.get_item(name)? {
                 if let Ok(inner) = inner.downcast() {
                     return visitor.visit_map(MapDeserializer::new(inner));
@@ -407,7 +407,7 @@ impl<'de, 'py> de::Deserializer<'de> for PyAnyDeserializer<'py> {
             });
         }
         if self.0.is_instance_of::<PyDict>() {
-            let dict: &Bound<PyDict> = self.0.downcast().unwrap();
+            let dict: &Bound<PyDict> = self.0.downcast()?;
             if dict.len() == 1 {
                 let key = dict.keys().get_item(0).unwrap();
                 let value = dict.values().get_item(0).unwrap();
@@ -430,10 +430,10 @@ impl<'de, 'py> de::Deserializer<'de> for PyAnyDeserializer<'py> {
         visitor: V,
     ) -> Result<V::Value> {
         if self.0.is_instance_of::<PyDict>() {
-            let dict: &Bound<PyDict> = self.0.downcast().unwrap(); // we just checked -- unwrapping is fine
+            let dict: &Bound<PyDict> = self.0.downcast()?;
             if let Some(value) = dict.get_item(name)? {
                 if value.is_instance_of::<PyTuple>() {
-                    let tuple: &Bound<PyTuple> = value.downcast().unwrap();
+                    let tuple: &Bound<PyTuple> = value.downcast()?;
                     return visitor.visit_seq(SeqDeserializer::from_tuple(tuple));
                 }
             }

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,5 +1,5 @@
 use crate::error::{Error, Result};
-use pyo3::types::*;
+use pyo3::{types::*, Bound};
 use serde::{
     de::{self, value::StrDeserializer, MapAccess, SeqAccess, Visitor},
     forward_to_deserialize_any, Deserialize, Deserializer,
@@ -18,17 +18,17 @@ use serde::{
 /// Python::with_gil(|py| {
 ///     // integer
 ///     let any: Py<PyAny> = 42.into_py(py);
-///     let i: i32 = from_pyobject(any.into_ref(py)).unwrap();
+///     let i: i32 = from_pyobject(any.into_bound(py)).unwrap();
 ///     assert_eq!(i, 42);
 ///
 ///     // float
 ///     let any: Py<PyAny> = (0.1).into_py(py);
-///     let x: f32 = from_pyobject(any.into_ref(py)).unwrap();
+///     let x: f32 = from_pyobject(any.into_bound(py)).unwrap();
 ///     assert_eq!(x, 0.1);
 ///
 ///     // bool
 ///     let any: Py<PyAny> = true.into_py(py);
-///     let x: bool = from_pyobject(any.into_ref(py)).unwrap();
+///     let x: bool = from_pyobject(any.into_bound(py)).unwrap();
 ///     assert_eq!(x, true);
 /// });
 /// ```
@@ -41,11 +41,11 @@ use serde::{
 ///
 /// Python::with_gil(|py| {
 ///     let none = py.None();
-///     let option: Option<i32> = from_pyobject(none.into_ref(py)).unwrap();
+///     let option: Option<i32> = from_pyobject(none.into_bound(py)).unwrap();
 ///     assert_eq!(option, None);
 ///
 ///     let py_int: Py<PyAny> = 42.into_py(py);
-///     let i: Option<i32> = from_pyobject(py_int.into_ref(py)).unwrap();
+///     let i: Option<i32> = from_pyobject(py_int.into_bound(py)).unwrap();
 ///     assert_eq!(i, Some(42));
 /// })
 /// ```
@@ -57,7 +57,7 @@ use serde::{
 /// use serde_pyobject::from_pyobject;
 ///
 /// Python::with_gil(|py| {
-///     let py_unit = PyTuple::empty(py);
+///     let py_unit = PyTuple::empty_bound(py);
 ///     let unit: () = from_pyobject(py_unit).unwrap();
 ///     assert_eq!(unit, ());
 /// })
@@ -74,7 +74,7 @@ use serde::{
 /// struct UnitStruct;
 ///
 /// Python::with_gil(|py| {
-///     let py_unit = PyTuple::empty(py);
+///     let py_unit = PyTuple::empty_bound(py);
 ///     let unit: UnitStruct = from_pyobject(py_unit).unwrap();
 ///     assert_eq!(unit, UnitStruct);
 /// })
@@ -94,7 +94,7 @@ use serde::{
 /// }
 ///
 /// Python::with_gil(|py| {
-///     let any = PyString::new(py, "A");
+///     let any = PyString::new_bound(py, "A");
 ///     let out: E = from_pyobject(any).unwrap();
 ///     assert_eq!(out, E::A);
 /// })
@@ -104,14 +104,14 @@ use serde::{
 ///
 /// ```
 /// use serde::Deserialize;
-/// use pyo3::{Python, PyAny, IntoPy};
+/// use pyo3::{Python, Bound, PyAny, IntoPy};
 /// use serde_pyobject::from_pyobject;
 ///
 /// #[derive(Debug, PartialEq, Deserialize)]
 /// struct NewTypeStruct(u8);
 ///
 /// Python::with_gil(|py| {
-///     let any: &PyAny = 1_u32.into_py(py).into_ref(py);
+///     let any: Bound<PyAny> = 1_u32.into_py(py).into_bound(py);
 ///     let obj: NewTypeStruct = from_pyobject(any).unwrap();
 ///     assert_eq!(obj, NewTypeStruct(1));
 /// });
@@ -156,7 +156,7 @@ use serde::{
 /// use serde_pyobject::from_pyobject;
 ///
 /// Python::with_gil(|py| {
-///     let tuple = PyTuple::new(py, &[1, 2, 3]);
+///     let tuple = PyTuple::new_bound(py, &[1, 2, 3]);
 ///     let tuple: (i32, i32, i32) = from_pyobject(tuple).unwrap();
 ///     assert_eq!(tuple, (1, 2, 3));
 /// });
@@ -173,7 +173,7 @@ use serde::{
 /// struct T(u8, String);
 ///
 /// Python::with_gil(|py| {
-///     let tuple = PyTuple::new(py, &[1_u32.into_py(py), "test".into_py(py)]);
+///     let tuple = PyTuple::new_bound(py, &[1_u32.into_py(py), "test".into_py(py)]);
 ///     let obj: T = from_pyobject(tuple).unwrap();
 ///     assert_eq!(obj, T(1, "test".to_string()));
 /// });
@@ -236,7 +236,7 @@ use serde::{
 ///         "b" => "test"
 ///     }
 ///     .unwrap();
-///     let a: A = from_pyobject(dict.into_ref(py)).unwrap();
+///     let a: A = from_pyobject(dict.into_bound(py)).unwrap();
 ///     assert_eq!(
 ///         a,
 ///         A {
@@ -255,7 +255,7 @@ use serde::{
 ///         .unwrap()
 ///     }
 ///     .unwrap();
-///     let a: A = from_pyobject(dict.into_ref(py)).unwrap();
+///     let a: A = from_pyobject(dict.into_bound(py)).unwrap();
 ///     assert_eq!(
 ///         a,
 ///         A {
@@ -292,11 +292,12 @@ use serde::{
 ///     assert_eq!(obj, StructVariant::S { r: 1, g: 2, b: 3 });
 /// });
 /// ```
-pub fn from_pyobject<'py, 'de, T: Deserialize<'de>>(any: &'py PyAny) -> Result<T> {
+pub fn from_pyobject<'py, 'de, T: Deserialize<'de>, Any>(any: Bound<'py, Any>) -> Result<T> {
+    let any = any.into_any();
     T::deserialize(PyAnyDeserializer(any))
 }
 
-struct PyAnyDeserializer<'py>(&'py PyAny);
+struct PyAnyDeserializer<'py>(Bound<'py, PyAny>);
 
 impl<'de, 'py> de::Deserializer<'de> for PyAnyDeserializer<'py> {
     type Error = Error;
@@ -306,13 +307,13 @@ impl<'de, 'py> de::Deserializer<'de> for PyAnyDeserializer<'py> {
         V: Visitor<'de>,
     {
         if self.0.is_instance_of::<PyDict>() {
-            return visitor.visit_map(MapDeserializer::new(self.0.extract()?));
+            return visitor.visit_map(MapDeserializer::new(self.0.downcast().unwrap()));
         }
         if self.0.is_instance_of::<PyList>() {
-            return visitor.visit_seq(SeqDeserializer::from_list(self.0.extract()?));
+            return visitor.visit_seq(SeqDeserializer::from_list(self.0.downcast().unwrap()));
         }
         if self.0.is_instance_of::<PyTuple>() {
-            return visitor.visit_seq(SeqDeserializer::from_tuple(self.0.extract()?));
+            return visitor.visit_seq(SeqDeserializer::from_tuple(self.0.downcast().unwrap()));
         }
         if self.0.is_instance_of::<PyString>() {
             return visitor.visit_str(self.0.extract()?);
@@ -341,9 +342,9 @@ impl<'de, 'py> de::Deserializer<'de> for PyAnyDeserializer<'py> {
     ) -> Result<V::Value> {
         // Nested dict `{ "A": { "a": 1, "b": 2 } }` is deserialized as `A { a: 1, b: 2 }`
         if self.0.is_instance_of::<PyDict>() {
-            let dict: &PyDict = self.0.extract()?;
+            let dict: &Bound<PyDict> = self.0.downcast().unwrap();
             if let Some(inner) = dict.get_item(name)? {
-                if let Ok(inner) = inner.extract() {
+                if let Ok(inner) = inner.downcast() {
                     return visitor.visit_map(MapDeserializer::new(inner));
                 }
             }
@@ -371,7 +372,7 @@ impl<'de, 'py> de::Deserializer<'de> for PyAnyDeserializer<'py> {
     }
 
     fn deserialize_unit<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        if self.0.is(PyTuple::empty(self.0.py())) {
+        if self.0.is(&PyTuple::empty_bound(self.0.py())) {
             visitor.visit_unit()
         } else {
             self.deserialize_any(visitor)
@@ -383,7 +384,7 @@ impl<'de, 'py> de::Deserializer<'de> for PyAnyDeserializer<'py> {
         _name: &'static str,
         visitor: V,
     ) -> Result<V::Value> {
-        if self.0.is(PyTuple::empty(self.0.py())) {
+        if self.0.is(&PyTuple::empty_bound(self.0.py())) {
             visitor.visit_unit()
         } else {
             self.deserialize_any(visitor)
@@ -399,14 +400,14 @@ impl<'de, 'py> de::Deserializer<'de> for PyAnyDeserializer<'py> {
         if self.0.is_instance_of::<PyString>() {
             let variant = self.0.extract()?;
             let py = self.0.py();
-            let none = py.None().into_ref(py);
+            let none = py.None().into_bound(py);
             return visitor.visit_enum(EnumDeserializer {
                 variant,
                 inner: none,
             });
         }
         if self.0.is_instance_of::<PyDict>() {
-            let dict: &PyDict = self.0.extract()?;
+            let dict: &Bound<PyDict> = self.0.downcast().unwrap();
             if dict.len() == 1 {
                 let key = dict.keys().get_item(0).unwrap();
                 let value = dict.values().get_item(0).unwrap();
@@ -429,10 +430,10 @@ impl<'de, 'py> de::Deserializer<'de> for PyAnyDeserializer<'py> {
         visitor: V,
     ) -> Result<V::Value> {
         if self.0.is_instance_of::<PyDict>() {
-            let dict: &PyDict = self.0.extract()?;
+            let dict: &Bound<PyDict> = self.0.downcast().unwrap(); // we just checked -- unwrapping is fine
             if let Some(value) = dict.get_item(name)? {
                 if value.is_instance_of::<PyTuple>() {
-                    let tuple: &PyTuple = value.extract()?;
+                    let tuple: &Bound<PyTuple> = value.downcast().unwrap();
                     return visitor.visit_seq(SeqDeserializer::from_tuple(tuple));
                 }
             }
@@ -448,11 +449,11 @@ impl<'de, 'py> de::Deserializer<'de> for PyAnyDeserializer<'py> {
 }
 
 struct SeqDeserializer<'py> {
-    seq_reversed: Vec<&'py PyAny>,
+    seq_reversed: Vec<Bound<'py, PyAny>>,
 }
 
 impl<'py> SeqDeserializer<'py> {
-    fn from_list(list: &'py PyList) -> Self {
+    fn from_list(list: &Bound<'py, PyList>) -> Self {
         let mut seq_reversed = Vec::new();
         for item in list.iter().rev() {
             seq_reversed.push(item);
@@ -460,7 +461,7 @@ impl<'py> SeqDeserializer<'py> {
         Self { seq_reversed }
     }
 
-    fn from_tuple(tuple: &'py PyTuple) -> Self {
+    fn from_tuple(tuple: &Bound<'py, PyTuple>) -> Self {
         let mut seq_reversed = Vec::new();
         for item in tuple.iter().rev() {
             seq_reversed.push(item);
@@ -483,12 +484,12 @@ impl<'de, 'py> SeqAccess<'de> for SeqDeserializer<'py> {
 }
 
 struct MapDeserializer<'py> {
-    keys: Vec<&'py PyAny>,
-    values: Vec<&'py PyAny>,
+    keys: Vec<Bound<'py, PyAny>>,
+    values: Vec<Bound<'py, PyAny>>,
 }
 
 impl<'py> MapDeserializer<'py> {
-    fn new(dict: &'py PyDict) -> Self {
+    fn new(dict: &Bound<'py, PyDict>) -> Self {
         let mut keys = Vec::new();
         let mut values = Vec::new();
         for (key, value) in dict.iter() {
@@ -527,9 +528,10 @@ impl<'de, 'py> MapAccess<'de> for MapDeserializer<'py> {
     }
 }
 
+// this lifetime is technically no longer 'py
 struct EnumDeserializer<'py> {
     variant: &'py str,
-    inner: &'py PyAny,
+    inner: Bound<'py, PyAny>,
 }
 
 impl<'de, 'py> de::EnumAccess<'de> for EnumDeserializer<'py> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use pyo3::{exceptions::PyRuntimeError, PyErr};
+use pyo3::{exceptions::PyRuntimeError, DowncastError, PyErr};
 use serde::{de, ser};
 use std::fmt::{self, Display};
 
@@ -8,6 +8,13 @@ pub struct Error(pub PyErr);
 
 impl From<PyErr> for Error {
     fn from(err: PyErr) -> Self {
+        Error(err)
+    }
+}
+
+impl From<DowncastError<'_, '_>> for Error {
+    fn from(err: DowncastError) -> Self {
+        let err: PyErr = err.into();
         Error(err)
     }
 }

--- a/src/pylit.rs
+++ b/src/pylit.rs
@@ -3,14 +3,14 @@
 /// Examples
 /// ---------
 ///
-/// - When you have GIL marker `py`, you can pass it and get a reference `PyResult<&PyDict>`:
+/// - When you have GIL marker `py`, you can pass it and get a Bound pointer `PyResult<Bound<PyDict>>`:
 ///
 /// ```
-/// use pyo3::{Python, types::PyDict};
+/// use pyo3::{Python, Bound, types::{PyDict, PyDictMethods, PyAnyMethods}};
 /// use serde_pyobject::pydict;
 ///
 /// Python::with_gil(|py| {
-///     let dict: &PyDict = pydict! {
+///     let dict: Bound<PyDict> = pydict! {
 ///         py,
 ///         "foo" => 42,
 ///         "bar" => "baz"
@@ -39,7 +39,7 @@
 /// - When you don't have GIL marker, you get a `PyResult<Py<PyDict>>`:
 ///
 /// ```
-/// use pyo3::{Python, Py, types::PyDict};
+/// use pyo3::{Python, Py, types::{PyDict, PyDictMethods, PyAnyMethods}};
 /// use serde_pyobject::pydict;
 ///
 /// let dict: Py<PyDict> = pydict! {
@@ -49,7 +49,7 @@
 /// .unwrap();
 ///
 /// Python::with_gil(|py| {
-///     let dict = dict.into_ref(py);
+///     let dict = dict.into_bound(py);
 ///     assert_eq!(
 ///         dict.get_item("foo")
 ///             .unwrap()
@@ -72,8 +72,9 @@
 #[macro_export]
 macro_rules! pydict {
     ($py:expr, $($key:expr => $value:expr),*) => {
-        (|| -> $crate::pyo3::PyResult<& $crate::pyo3::types::PyDict> {
-            let dict = $crate::pyo3::types::PyDict::new($py);
+        (|| -> $crate::pyo3::PyResult<$crate::pyo3::Bound<$crate::pyo3::types::PyDict>> {
+            use $crate::pyo3::types::PyDictMethods;
+            let dict = $crate::pyo3::types::PyDict::new_bound($py);
             $(dict.set_item($key, $value)?;)*
             Ok(dict)
         })()
@@ -94,7 +95,7 @@ macro_rules! pydict {
 /// - When you have GIL marker `py`, you can pass it and get a reference `PyResult<&PyList>`:
 ///
 /// ```
-/// use pyo3::{Python, types::PyList};
+/// use pyo3::{Python, types::{PyList, PyListMethods, PyAnyMethods}};
 /// use serde_pyobject::pylist;
 ///
 /// Python::with_gil(|py| {
@@ -108,13 +109,13 @@ macro_rules! pydict {
 /// - When you don't have GIL marker, you get a `PyResult<Py<PyList>>`:
 ///
 /// ```
-/// use pyo3::{Python, Py, types::PyList};
+/// use pyo3::{Python, Py, types::{PyList, PyListMethods, PyAnyMethods}};
 /// use serde_pyobject::pylist;
 ///
 /// let list: Py<PyList> = pylist![1, "two"].unwrap();
 ///
 /// Python::with_gil(|py| {
-///    let list = list.into_ref(py);
+///    let list = list.into_bound(py);
 ///    assert_eq!(list.len(), 2);
 ///    assert_eq!(list.get_item(0).unwrap().extract::<i32>().unwrap(), 1);
 ///    assert_eq!(list.get_item(1).unwrap().extract::<&str>().unwrap(), "two");
@@ -124,8 +125,9 @@ macro_rules! pydict {
 #[macro_export]
 macro_rules! pylist {
     ($py:expr; $($value:expr),*) => {
-        (|| -> $crate::pyo3::PyResult<& $crate::pyo3::types::PyList> {
-            let list = $crate::pyo3::types::PyList::empty($py);
+        (|| -> $crate::pyo3::PyResult<$crate::pyo3::Bound<$crate::pyo3::types::PyList>> {
+            use $crate::pyo3::types::PyListMethods;
+            let list = $crate::pyo3::types::PyList::empty_bound($py);
             $(list.append($value)?;)*
             Ok(list)
         })()

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -12,7 +12,7 @@ use serde::{ser, Serialize};
 /// ## string
 ///
 /// ```
-/// use pyo3::{Python, types::PyString};
+/// use pyo3::{Python, types::{PyString, PyAnyMethods}};
 /// use serde_pyobject::to_pyobject;
 ///
 /// Python::with_gil(|py| {
@@ -28,7 +28,7 @@ use serde::{ser, Serialize};
 /// ## integer
 ///
 /// ```
-/// use pyo3::{Python, types::PyLong};
+/// use pyo3::{Python, types::{PyLong, PyAnyMethods}};
 /// use serde_pyobject::to_pyobject;
 ///
 /// Python::with_gil(|py| {
@@ -46,7 +46,7 @@ use serde::{ser, Serialize};
 /// ## float
 ///
 /// ```
-/// use pyo3::{Python, types::PyFloat};
+/// use pyo3::{Python, types::{PyFloat, PyAnyMethods}};
 /// use serde_pyobject::to_pyobject;
 ///
 /// Python::with_gil(|py| {
@@ -63,7 +63,7 @@ use serde::{ser, Serialize};
 /// Rust `None` is serialized to Python `None`, and `Some(value)` is serialized as `value` is serialized
 ///
 /// ```
-/// use pyo3::{Python, types::PyLong};
+/// use pyo3::{Python, types::{PyLong, PyAnyMethods}};
 /// use serde_pyobject::to_pyobject;
 ///
 /// Python::with_gil(|py| {
@@ -80,7 +80,7 @@ use serde::{ser, Serialize};
 /// Rust's `()` is serialized to Python's `()`
 ///
 /// ```
-/// use pyo3::{Python, types::PyTuple};
+/// use pyo3::{Python, types::{PyTuple, PyAnyMethods}};
 /// use serde_pyobject::to_pyobject;
 ///
 /// Python::with_gil(|py| {
@@ -95,7 +95,7 @@ use serde::{ser, Serialize};
 ///
 /// ```
 /// use serde::Serialize;
-/// use pyo3::{Python, types::PyTuple};
+/// use pyo3::{Python, types::{PyTuple, PyAnyMethods}};
 /// use serde_pyobject::{to_pyobject, pydict};
 ///
 /// #[derive(Serialize)]
@@ -111,7 +111,7 @@ use serde::{ser, Serialize};
 ///
 /// ```
 /// use serde::Serialize;
-/// use pyo3::{Python, types::PyTuple};
+/// use pyo3::{Python, types::{PyTuple, PyAnyMethods}};
 /// use serde_pyobject::{to_pyobject, pydict};
 ///
 /// #[derive(Serialize)]
@@ -132,7 +132,7 @@ use serde::{ser, Serialize};
 ///
 /// ```
 /// use serde::Serialize;
-/// use pyo3::{Python, types::PyLong};
+/// use pyo3::{Python, types::{PyLong, PyAnyMethods}};
 /// use serde_pyobject::to_pyobject;
 ///
 /// #[derive(Serialize)]
@@ -149,7 +149,7 @@ use serde::{ser, Serialize};
 ///
 /// ```
 /// use serde::Serialize;
-/// use pyo3::Python;
+/// use pyo3::{Python, types::PyAnyMethods};
 /// use serde_pyobject::{to_pyobject, pydict};
 ///
 /// #[derive(Serialize)]
@@ -166,7 +166,7 @@ use serde::{ser, Serialize};
 /// ## seq
 ///
 /// ```
-/// use pyo3::Python;
+/// use pyo3::{Python, types::PyAnyMethods};
 /// use serde_pyobject::{to_pyobject, pylist};
 ///
 /// Python::with_gil(|py| {
@@ -178,7 +178,7 @@ use serde::{ser, Serialize};
 /// ## tuple
 ///
 /// ```
-/// use pyo3::{IntoPy, Python, types::PyTuple};
+/// use pyo3::{IntoPy, Python, types::{PyTuple, PyAnyMethods}};
 /// use serde_pyobject::to_pyobject;
 ///
 /// Python::with_gil(|py| {
@@ -190,7 +190,7 @@ use serde::{ser, Serialize};
 /// ## tuple struct
 ///
 /// ```
-/// use pyo3::{Python, types::PyTuple};
+/// use pyo3::{Python, types::{PyTuple, PyAnyMethods}};
 /// use serde::Serialize;
 /// use serde_pyobject::to_pyobject;
 ///
@@ -206,7 +206,7 @@ use serde::{ser, Serialize};
 /// ## tuple variant
 ///
 /// ```
-/// use pyo3::Python;
+/// use pyo3::{Python, types::PyAnyMethods};
 /// use serde::Serialize;
 /// use serde_pyobject::{to_pyobject, pydict};
 ///
@@ -224,7 +224,7 @@ use serde::{ser, Serialize};
 /// ## map
 ///
 /// ```
-/// use pyo3::Python;
+/// use pyo3::{Python, types::PyAnyMethods};
 /// use serde_pyobject::{to_pyobject, pydict};
 /// use maplit::hashmap;
 ///
@@ -246,7 +246,7 @@ use serde::{ser, Serialize};
 ///
 /// ```
 /// use serde::Serialize;
-/// use pyo3::{IntoPy, Python, types::PyTuple};
+/// use pyo3::{IntoPy, Python, types::{PyTuple, PyAnyMethods}};
 /// use serde_pyobject::{to_pyobject, pydict};
 ///
 /// #[derive(Serialize)]
@@ -265,7 +265,7 @@ use serde::{ser, Serialize};
 ///
 /// ```
 /// use serde::Serialize;
-/// use pyo3::Python;
+/// use pyo3::{Python, types::PyAnyMethods};
 /// use serde_pyobject::{to_pyobject, pydict};
 ///
 /// #[derive(Serialize)]
@@ -288,7 +288,7 @@ use serde::{ser, Serialize};
 ///     );
 /// });
 /// ```
-pub fn to_pyobject<'py, T>(py: Python<'py>, value: &T) -> Result<&'py PyAny>
+pub fn to_pyobject<'py, T>(py: Python<'py>, value: &T) -> Result<Bound<'py, PyAny>>
 where
     T: Serialize + ?Sized,
 {
@@ -303,13 +303,13 @@ pub struct PyAnySerializer<'py> {
 macro_rules! serialize_integer {
     ($f:ident, $t:ty) => {
         fn $f(self, v: $t) -> Result<Self::Ok> {
-            Ok(v.into_py(self.py).into_ref(self.py))
+            Ok(v.into_py(self.py).into_bound(self.py))
         }
     };
 }
 
 impl<'py> ser::Serializer for PyAnySerializer<'py> {
-    type Ok = &'py PyAny;
+    type Ok = Bound<'py, PyAny>;
 
     type Error = Error;
 
@@ -322,7 +322,7 @@ impl<'py> ser::Serializer for PyAnySerializer<'py> {
     type SerializeStructVariant = StructVariant<'py>;
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok> {
-        Ok(PyBool::new(self.py, v))
+        Ok(PyBool::new_bound(self.py, v).to_owned().into_any())
     }
 
     serialize_integer!(serialize_i8, i8);
@@ -335,28 +335,28 @@ impl<'py> ser::Serializer for PyAnySerializer<'py> {
     serialize_integer!(serialize_u64, u64);
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok> {
-        Ok(PyFloat::new(self.py, v as f64))
+        Ok(PyFloat::new_bound(self.py, v as f64).into_any())
     }
 
     fn serialize_f64(self, v: f64) -> Result<Self::Ok> {
-        Ok(PyFloat::new(self.py, v))
+        Ok(PyFloat::new_bound(self.py, v).into_any())
     }
 
     fn serialize_char(self, v: char) -> Result<Self::Ok> {
         let s = v.to_string();
-        Ok(PyString::new(self.py, &s))
+        Ok(PyString::new_bound(self.py, &s).into_any())
     }
 
     fn serialize_str(self, v: &str) -> Result<Self::Ok> {
-        Ok(PyString::new(self.py, v))
+        Ok(PyString::new_bound(self.py, v).into_any())
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok> {
-        Ok(PyByteArray::new(self.py, v))
+        Ok(PyByteArray::new_bound(self.py, v).into_any())
     }
 
     fn serialize_none(self) -> Result<Self::Ok> {
-        Ok(self.py.None().into_ref(self.py))
+        Ok(self.py.None().into_bound(self.py))
     }
 
     fn serialize_some<T>(self, value: &T) -> Result<Self::Ok>
@@ -368,11 +368,11 @@ impl<'py> ser::Serializer for PyAnySerializer<'py> {
     }
 
     fn serialize_unit(self) -> Result<Self::Ok> {
-        Ok(PyTuple::empty(self.py))
+        Ok(PyTuple::empty_bound(self.py).into_any())
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok> {
-        Ok(PyTuple::empty(self.py))
+        Ok(PyTuple::empty_bound(self.py).into_any())
     }
 
     fn serialize_unit_variant(
@@ -381,7 +381,7 @@ impl<'py> ser::Serializer for PyAnySerializer<'py> {
         _index: u32,
         variant: &'static str,
     ) -> Result<Self::Ok> {
-        Ok(PyString::new(self.py, variant))
+        Ok(PyString::new_bound(self.py, variant).into_any())
     }
 
     fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Self::Ok>
@@ -401,7 +401,7 @@ impl<'py> ser::Serializer for PyAnySerializer<'py> {
     where
         T: ?Sized + Serialize,
     {
-        let dict = PyDict::new(self.py);
+        let dict = PyDict::new_bound(self.py).into_any();
         dict.set_item(variant, value.serialize(self)?)?;
         Ok(dict)
     }
@@ -448,7 +448,7 @@ impl<'py> ser::Serializer for PyAnySerializer<'py> {
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
         Ok(Map {
             py: self.py,
-            map: PyDict::new(self.py),
+            map: PyDict::new_bound(self.py),
             key: None,
         })
     }
@@ -456,7 +456,7 @@ impl<'py> ser::Serializer for PyAnySerializer<'py> {
     fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
         Ok(Struct {
             py: self.py,
-            fields: PyDict::new(self.py),
+            fields: PyDict::new_bound(self.py),
         })
     }
 
@@ -470,18 +470,18 @@ impl<'py> ser::Serializer for PyAnySerializer<'py> {
         Ok(StructVariant {
             py: self.py,
             variant,
-            fields: PyDict::new(self.py),
+            fields: PyDict::new_bound(self.py),
         })
     }
 }
 
 pub struct Seq<'py> {
     py: Python<'py>,
-    seq: Vec<&'py PyAny>,
+    seq: Vec<Bound<'py, PyAny>>,
 }
 
 impl<'py> ser::SerializeSeq for Seq<'py> {
-    type Ok = &'py PyAny;
+    type Ok = Bound<'py, PyAny>;
     type Error = Error;
 
     fn serialize_element<T>(&mut self, value: &T) -> Result<()>
@@ -494,12 +494,12 @@ impl<'py> ser::SerializeSeq for Seq<'py> {
     }
 
     fn end(self) -> Result<Self::Ok> {
-        Ok(PyList::new(self.py, self.seq))
+        Ok(PyList::new_bound(self.py, self.seq).into_any())
     }
 }
 
 impl<'py> ser::SerializeTuple for Seq<'py> {
-    type Ok = &'py PyAny;
+    type Ok = Bound<'py, PyAny>;
     type Error = Error;
 
     fn serialize_element<T>(&mut self, value: &T) -> Result<()>
@@ -512,17 +512,17 @@ impl<'py> ser::SerializeTuple for Seq<'py> {
     }
 
     fn end(self) -> Result<Self::Ok> {
-        Ok(PyTuple::new(self.py, self.seq))
+        Ok(PyTuple::new_bound(self.py, self.seq).into_any())
     }
 }
 
 pub struct TupleStruct<'py> {
     py: Python<'py>,
-    fields: Vec<&'py PyAny>,
+    fields: Vec<Bound<'py, PyAny>>,
 }
 
 impl<'py> ser::SerializeTupleStruct for TupleStruct<'py> {
-    type Ok = &'py PyAny;
+    type Ok = Bound<'py, PyAny>;
     type Error = Error;
 
     fn serialize_field<T>(&mut self, value: &T) -> Result<()>
@@ -535,18 +535,18 @@ impl<'py> ser::SerializeTupleStruct for TupleStruct<'py> {
     }
 
     fn end(self) -> Result<Self::Ok> {
-        Ok(PyTuple::new(self.py, self.fields))
+        Ok(PyTuple::new_bound(self.py, self.fields).into_any())
     }
 }
 
 pub struct TupleVariant<'py> {
     py: Python<'py>,
     variant: &'static str,
-    fields: Vec<&'py PyAny>,
+    fields: Vec<Bound<'py, PyAny>>,
 }
 
 impl<'py> ser::SerializeTupleVariant for TupleVariant<'py> {
-    type Ok = &'py PyAny;
+    type Ok = Bound<'py, PyAny>;
     type Error = Error;
 
     fn serialize_field<T>(&mut self, value: &T) -> Result<()>
@@ -559,20 +559,20 @@ impl<'py> ser::SerializeTupleVariant for TupleVariant<'py> {
     }
 
     fn end(self) -> Result<Self::Ok> {
-        let dict = PyDict::new(self.py);
-        dict.set_item(self.variant, PyTuple::new(self.py, self.fields))?;
-        Ok(dict)
+        let dict = PyDict::new_bound(self.py);
+        dict.set_item(self.variant, PyTuple::new_bound(self.py, self.fields))?;
+        Ok(dict.into_any())
     }
 }
 
 pub struct Map<'py> {
     py: Python<'py>,
-    map: &'py PyDict,
-    key: Option<&'py PyAny>,
+    map: Bound<'py, PyDict>,
+    key: Option<Bound<'py, PyAny>>,
 }
 
 impl<'py> ser::SerializeMap for Map<'py> {
-    type Ok = &'py PyAny;
+    type Ok = Bound<'py, PyAny>;
     type Error = Error;
 
     fn serialize_key<T>(&mut self, key: &T) -> Result<()>
@@ -597,17 +597,17 @@ impl<'py> ser::SerializeMap for Map<'py> {
     }
 
     fn end(self) -> Result<Self::Ok> {
-        Ok(self.map)
+        Ok(self.map.into_any())
     }
 }
 
 pub struct Struct<'py> {
     py: Python<'py>,
-    fields: &'py PyDict,
+    fields: Bound<'py, PyDict>,
 }
 
 impl<'py> ser::SerializeStruct for Struct<'py> {
-    type Ok = &'py PyAny;
+    type Ok = Bound<'py, PyAny>;
     type Error = Error;
 
     fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
@@ -620,18 +620,18 @@ impl<'py> ser::SerializeStruct for Struct<'py> {
     }
 
     fn end(self) -> Result<Self::Ok> {
-        Ok(self.fields)
+        Ok(self.fields.into_any())
     }
 }
 
 pub struct StructVariant<'py> {
     py: Python<'py>,
     variant: &'static str,
-    fields: &'py PyDict,
+    fields: Bound<'py, PyDict>,
 }
 
 impl<'py> ser::SerializeStructVariant for StructVariant<'py> {
-    type Ok = &'py PyAny;
+    type Ok = Bound<'py, PyAny>;
     type Error = Error;
 
     fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
@@ -644,8 +644,8 @@ impl<'py> ser::SerializeStructVariant for StructVariant<'py> {
     }
 
     fn end(self) -> Result<Self::Ok> {
-        let dict = PyDict::new(self.py);
+        let dict = PyDict::new_bound(self.py);
         dict.set_item(self.variant, self.fields)?;
-        Ok(dict)
+        Ok(dict.into_any())
     }
 }

--- a/tests/to_json_to_pyobject.rs
+++ b/tests/to_json_to_pyobject.rs
@@ -2,9 +2,9 @@ use maplit::*;
 use pyo3::prelude::*;
 use serde::Serialize;
 
-fn to_json_to_pyobject<'py, T: Serialize>(py: Python<'py>, obj: T) -> PyResult<&'py PyAny> {
+fn to_json_to_pyobject<T: Serialize>(py: Python<'_>, obj: T) -> PyResult<Bound<PyAny>> {
     let json = serde_json::to_string(&obj).unwrap();
-    let obj = py.import("json")?.getattr("loads")?.call1((json,))?;
+    let obj = py.import_bound("json")?.getattr("loads")?.call1((json,))?;
     Ok(obj)
 }
 


### PR DESCRIPTION
Updates to the new Bound api in Pyo3 v0.21. This replaces all the usages of the old api with the Bound equivalents. We could theoretically support both but it seems like extra work for little gain considering the future removal of the old API.

There may be some edge cases with strings and stuff where this isn't _100%_ the same in terms of cloning/borrowing, but this should be mostly equivalent, as far as I can tell.

I wasn't sure if there was any reason for doing `is_instance_of` every time before `downcast/extract` instead of the `if let Ok(...) = ` style, but I left it as is either way to save time.
