### PR TITLE
Support PyO3's `abi3-py38` feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,3 +92,9 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+      - name: Run tests with abi3 feature
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features abi3-py38

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ maplit = "1.0.2"
 pyo3 = { version = "0.21.0", features = ["auto-initialize"] }
 serde = { version = "1.0.190", features = ["derive"] }
 serde_json = "1.0.108"
+
+[features]
+abi3-py38 = ["pyo3/abi3-py38"]

--- a/src/de.rs
+++ b/src/de.rs
@@ -316,7 +316,7 @@ impl<'de, 'py> de::Deserializer<'de> for PyAnyDeserializer<'py> {
             return visitor.visit_seq(SeqDeserializer::from_tuple(self.0.downcast()?));
         }
         if self.0.is_instance_of::<PyString>() {
-            return visitor.visit_str(self.0.extract()?);
+            return visitor.visit_str(&self.0.extract::<String>()?);
         }
         if self.0.is_instance_of::<PyBool>() {
             // must be match before PyLong
@@ -398,11 +398,11 @@ impl<'de, 'py> de::Deserializer<'de> for PyAnyDeserializer<'py> {
         visitor: V,
     ) -> Result<V::Value> {
         if self.0.is_instance_of::<PyString>() {
-            let variant = self.0.extract()?;
+            let variant: String = self.0.extract()?;
             let py = self.0.py();
             let none = py.None().into_bound(py);
             return visitor.visit_enum(EnumDeserializer {
-                variant,
+                variant: &variant,
                 inner: none,
             });
         }
@@ -412,9 +412,9 @@ impl<'de, 'py> de::Deserializer<'de> for PyAnyDeserializer<'py> {
                 let key = dict.keys().get_item(0).unwrap();
                 let value = dict.values().get_item(0).unwrap();
                 if key.is_instance_of::<PyString>() {
-                    let variant = key.extract()?;
+                    let variant: String = key.extract()?;
                     return visitor.visit_enum(EnumDeserializer {
-                        variant,
+                        variant: &variant,
                         inner: value,
                     });
                 }

--- a/src/pylit.rs
+++ b/src/pylit.rs
@@ -102,7 +102,7 @@ macro_rules! pydict {
 ///     let list = pylist![py; 1, "two"].unwrap();
 ///     assert_eq!(list.len(), 2);
 ///     assert_eq!(list.get_item(0).unwrap().extract::<i32>().unwrap(), 1);
-///     assert_eq!(list.get_item(1).unwrap().extract::<&str>().unwrap(), "two");
+///     assert_eq!(list.get_item(1).unwrap().extract::<String>().unwrap(), "two");
 /// })
 /// ```
 ///
@@ -118,7 +118,7 @@ macro_rules! pydict {
 ///    let list = list.into_bound(py);
 ///    assert_eq!(list.len(), 2);
 ///    assert_eq!(list.get_item(0).unwrap().extract::<i32>().unwrap(), 1);
-///    assert_eq!(list.get_item(1).unwrap().extract::<&str>().unwrap(), "two");
+///    assert_eq!(list.get_item(1).unwrap().extract::<String>().unwrap(), "two");
 /// });
 /// ```
 ///


### PR DESCRIPTION
`extract::<&str>` is replaced by `extract::<String>`. This means we take additional memcpy, but this crate is not intended to avoid this cost.