### PR TITLE
Update PyO3 to version 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ keywords      = ["serde", "pyo3", "python", "ffi"]
 license       = "MIT OR Apache-2.0"
 
 [dependencies]
-pyo3 = "0.21.0"
+pyo3 = "0.22.0"
 serde = "1.0.190"
 
 [dev-dependencies]
 maplit = "1.0.2"
-pyo3 = { version = "0.21.0", features = ["auto-initialize"] }
+pyo3 = { version = "0.22.0", features = ["auto-initialize"] }
 serde = { version = "1.0.190", features = ["derive"] }
 serde_json = "1.0.108"

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -85,7 +85,7 @@ use serde::{ser, Serialize};
 ///
 /// Python::with_gil(|py| {
 ///     let obj = to_pyobject(py, &()).unwrap();
-///     assert!(obj.is(PyTuple::empty(py)));
+///     assert!(obj.is(&PyTuple::empty_bound(py)));
 /// });
 /// ```
 ///
@@ -103,7 +103,7 @@ use serde::{ser, Serialize};
 ///
 /// Python::with_gil(|py| {
 ///     let obj = to_pyobject(py, &UnitStruct {}).unwrap();
-///     assert!(obj.eq(PyTuple::empty(py)).unwrap());
+///     assert!(obj.eq(PyTuple::empty_bound(py)).unwrap());
 /// });
 /// ```
 ///
@@ -183,7 +183,7 @@ use serde::{ser, Serialize};
 ///
 /// Python::with_gil(|py| {
 ///     let obj = to_pyobject(py, &(3, "test")).unwrap();
-///     assert!(obj.eq(PyTuple::new(py, [3.into_py(py), "test".into_py(py)])).unwrap());
+///     assert!(obj.eq(PyTuple::new_bound(py, [3.into_py(py), "test".into_py(py)])).unwrap());
 /// });
 /// ```
 ///
@@ -199,7 +199,7 @@ use serde::{ser, Serialize};
 ///
 /// Python::with_gil(|py| {
 ///     let obj = to_pyobject(py, &TupleStruct(1, 2, 3)).unwrap();
-///     assert!(obj.eq(PyTuple::new(py, [1, 2, 3])).unwrap());
+///     assert!(obj.eq(PyTuple::new_bound(py, [1, 2, 3])).unwrap());
 /// });
 /// ```
 ///


### PR DESCRIPTION
This updates PyO3 to version 0.22.0 and replaces the remaining uses of the old API (that now has been removed) with calls to the new `Bound<T>` API.