### PR TITLE
chore: bump pyo3 dependency boundary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords      = ["serde", "pyo3", "python", "ffi"]
 license       = "MIT OR Apache-2.0"
 
 [dependencies]
-pyo3 = "0.22.0"
+pyo3 = ">=0.22.0,<0.24.0"
 serde = "1.0.190"
 
 [dev-dependencies]


### PR DESCRIPTION
serede-pyobject seems to work fine with pyo3@0.23.2 (though it generates a bunch of deprecation warning), so it should be good to bump the upper bound.