### PR TITLE
ci: fixes artifact actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
         run: cargo doc --all --no-deps
 
       - name: Upload html
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rustdoc
           path: ./target/doc
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download rustdoc
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name: rustdoc
           path: .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,11 +58,11 @@ jobs:
         uses: actions/configure-pages@v3
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: '.'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Publish Docs CI fails due to the dependency to the vulnerable version of artifact actions. This PR fixes that.