### PR TITLE
Loosen dependency version constraints for pyo3, serde, and serde_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ keywords = ["serde", "pyo3", "python", "ffi"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-pyo3 = "0.23.0"
-serde = "1.0.190"
+pyo3 = ">=0.23"
+serde = ">=1.0"
 
 [dev-dependencies]
 maplit = "1.0.2"
-pyo3 = { version = "0.23.0", features = ["auto-initialize"] }
-serde = { version = "1.0.190", features = ["derive"] }
-serde_json = "1.0.108"
+pyo3 = { version = ">=0.23", features = ["auto-initialize"] }
+serde = { version = ">=1.0", features = ["derive"] }
+serde_json = ">=1.0"
 
 [features]
 abi3-py38 = ["pyo3/abi3-py38"]


### PR DESCRIPTION
**Description:**

This PR updates the version constraints for the dependencies in our `Cargo.toml` file to provide more flexibility in dependency resolution. Specifically:

- **Main Dependencies:**  
  - Changed `pyo3` from `"0.23.0"` to `">=0.23"`.
  - Changed `serde` from `"1.0.190"` to `">=1.0"`.

- **Dev Dependencies:**  
  - Updated `pyo3` from `{ version = "0.23.0", features = ["auto-initialize"] }` to `{ version = ">=0.23", features = ["auto-initialize"] }`.
  - Updated `serde` from `{ version = "1.0.190", features = ["derive"] }` to `{ version = ">=1.0", features = ["derive"] }`.
  - Updated `serde_json` from `"1.0.108"` to `">=1.0"`.

**Rationale:**

- **Flexibility:** Allowing versions greater than or equal to the specified minimum enables compatibility with newer releases and patch updates without forcing an immediate version bump across the board.
- **Ease of Maintenance:** This approach minimizes potential dependency conflicts, especially for downstream users who might already be using newer versions of `pyo3` or `serde`.

**Impact:**

- The changes are limited to version specification in `Cargo.toml` and should not affect the API or functionality.
- All tests are expected to pass as long as the newer versions remain backwards compatible.

Additionally, I check what the minimum supported pyo3 version is and it is 0.23.0.

Please review and let me know if further adjustments are needed.
