### PR TITLE
Enhance Python Object Deserialization via __dict__ Field

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -328,6 +328,9 @@ impl<'de> de::Deserializer<'de> for PyAnyDeserializer<'_> {
         if self.0.is_instance_of::<PyFloat>() {
             return visitor.visit_f64(self.0.extract()?);
         }
+        if self.0.hasattr("__dict__")? {
+            return visitor.visit_map(MapDeserializer::new(self.0.getattr("__dict__")?.downcast()?));
+        }
         if self.0.is_none() {
             return visitor.visit_none();
         }


### PR DESCRIPTION
This PR introduces an enhancement, allowing seamless deserialization of Python objects—specifically handling instances of Python classes.

## Overview

- **New Deserializer Check:**  
  The updated deserializer now includes a check to determine if the object being deserialized is an instance of a Python class. If it is, the implementation extracts the object's `__dict__` field, which contains the object's attributes as a dictionary. This dictionary is then used as the source for deserialization, allowing for a more natural mapping between Python objects and Rust data structures.

- **Improved Compatibility:**  
  With this enhancement, the wrapper now better supports the dynamic nature of Python objects. Users can now serialize and deserialize custom Python class instances without needing to implement extra boilerplate code to manually handle the conversion of attributes.

## Motivation

The primary motivation behind this change was to simplify the interoperability between Python and Rust for users who leverage Serde for serialization tasks. Python classes typically encapsulate their state within the `__dict__` attribute, and by automatically using it during deserialization, we:
  
- **Reduce Friction:**  
  Developers no longer need to write custom deserialization logic for Python class instances.
  
- **Increase Reliability:**  
  The wrapper can more reliably reconstruct Python objects in Rust by leveraging the built-in dictionary representation.

## Testing

- **Unit Tests:**  
  Added new unit tests covering:
  - Standard Python objects.
  - Custom Python class instances with populated `__dict__`.

## Future Work

- **Enhanced Error Reporting:**  
  Implementing https://github.com/Jij-Inc/serde-pyobject/issues/12

- **Support for More Pydantic BaseModel:**  
  Evaluate the possibility of extending similar logic to handle other Python-specific constructs like Pydantic BaseModels, which we can use the [model_dump](https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_dump) function instead.


